### PR TITLE
Update for XE19.1

### DIFF
--- a/EyeGestureDemoApp/src/com/polysfactory/eyegesturedemo/MainActivity.java
+++ b/EyeGestureDemoApp/src/com/polysfactory/eyegesturedemo/MainActivity.java
@@ -55,13 +55,6 @@ public class MainActivity extends Activity {
     @Override
     protected void onStart() {
         super.onStart();
-
-        mEyeGestureManager.stopDetector(target1);
-        mEyeGestureManager.stopDetector(target2);
-
-        mEyeGestureManager.enableDetectorPersistently(target1, true);
-        mEyeGestureManager.enableDetectorPersistently(target2, true);
-
         mEyeGestureManager.register(target1, mEyeGestureListener);
         mEyeGestureManager.register(target2, mEyeGestureListener);
     }
@@ -69,12 +62,8 @@ public class MainActivity extends Activity {
     @Override
     protected void onStop() {
         super.onStop();
-
         mEyeGestureManager.unregister(target1, mEyeGestureListener);
         mEyeGestureManager.unregister(target2, mEyeGestureListener);
-
-        mEyeGestureManager.stopDetector(target1);
-        mEyeGestureManager.stopDetector(target2);
     }
 
     private class EyeGestureListener implements Listener {

--- a/EyeGestureStub/src/com/google/android/glass/eye/EyeGestureManager.java
+++ b/EyeGestureStub/src/com/google/android/glass/eye/EyeGestureManager.java
@@ -29,14 +29,6 @@ public class EyeGestureManager {
         return false;
     }
 
-    public boolean enableDetectorPersistently(EyeGesture paramEyeGesture, boolean paramBoolean) {
-        return false;
-    }
-
-    public boolean enableDetectorPersistently(EyeGesture paramEyeGesture, boolean paramBoolean1, boolean paramBoolean2) {
-        return false;
-    }
-
     public void enableGazeService(boolean paramBoolean) {
     }
 
@@ -44,18 +36,7 @@ public class EyeGestureManager {
         return false;
     }
 
-    public void forceGlasshubResetHack() {
-    }
-
     public boolean isCalibrationComplete(EyeGesture paramEyeGesture) {
-        return false;
-    }
-
-    public boolean isDetectorPersistentlyEnabled(EyeGesture paramEyeGesture) {
-        return false;
-    }
-
-    public boolean isDetectorRunning(EyeGesture paramEyeGesture) {
         return false;
     }
 
@@ -84,18 +65,6 @@ public class EyeGestureManager {
     }
 
     public boolean startCalibrationInterval(EyeGesture paramEyeGesture) {
-        return false;
-    }
-
-    public boolean startDetector(EyeGesture paramEyeGesture, boolean paramBoolean) {
-        return false;
-    }
-
-    public boolean startDetector(EyeGesture paramEyeGesture, boolean paramBoolean, int paramInt) {
-        return false;
-    }
-
-    public boolean stopDetector(EyeGesture paramEyeGesture) {
         return false;
     }
 


### PR DESCRIPTION
Updated the stub because some methods were removed from EyeGestureManager.
(Some of them were moved to EyeGestureService.)

Now, we can't stop the wink feature because we can't call these 2 methods:
stopDetector
enableDetectorPersistently
